### PR TITLE
Bump bash-parser version to 0.4 & add bash-ast-traverser

### DIFF
--- a/example/sudo.js
+++ b/example/sudo.js
@@ -3,7 +3,7 @@ var fs = require('fs')
 var src = fs.readFileSync('rewire.sh','utf8')
 
 console.log(falafel(src, function (node) {
-  if (node.type === 'simple_command' && node.name.text === 'sudo') {
+  if (node.type === 'Command' && node.name.text === 'sudo') {
     node.name.update('SUDO')
   }
 }).toString())

--- a/index.js
+++ b/index.js
@@ -42,15 +42,15 @@ module.exports = function (src, opts, fn) {
   })(ast, undefined)
   return result
 }
- 
+
 function insertHelpers (offsets, node, parent, chunks) {
   node.parent = parent
   node.source = function () {
     return chunks.slice(node.start, node.end).join('')
   }
   if (node.loc) {
-    node.start = offsets[node.loc.startLine] + node.loc.startColumn
-    node.end = offsets[node.loc.endLine] + node.loc.endColumn + 1
+    node.start = node.loc.start.char
+    node.end = node.loc.end.char + 1
     delete node.loc
   }
   if (node.update && typeof node.update === 'object') {

--- a/index.js
+++ b/index.js
@@ -9,12 +9,7 @@ module.exports = function (src, opts, fn) {
     src = src.toString()
   }
   if (typeof src !== 'string') src = String(src)
-  var lines = src.split('\n')
-  var offset = 0, offsets = []
-  lines.forEach(function (line) {
-    offsets.push(offset)
-    offset += line.length + 1
-  })
+
   var ast = parse(src, { insertLOC: true })
   var result = {
     chunks : src.split(''),
@@ -22,7 +17,7 @@ module.exports = function (src, opts, fn) {
     inspect : function () { return result.toString() }
   }
   ;(function walk (node, parent) {
-    insertHelpers(offsets, node, parent, result.chunks)
+    insertHelpers(node, parent, result.chunks)
     Object.keys(node).forEach(function (key) {
       if (key === 'parent') return
       var child = node[key]
@@ -42,7 +37,7 @@ module.exports = function (src, opts, fn) {
   return result
 }
 
-function insertHelpers (offsets, node, parent, chunks) {
+function insertHelpers (node, parent, chunks) {
   node.parent = parent
   node.source = function () {
     return chunks.slice(node.start, node.end).join('')

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "author": "substack",
   "license": "BSD",
   "dependencies": {
-    "bash-parser": "~0.3.2"
+    "bash-parser": "~0.4.0"
   },
   "devDependencies": {
     "tape": "^4.6.2"

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "author": "substack",
   "license": "BSD",
   "dependencies": {
+    "bash-ast-traverser": "^0.4.1",
     "bash-parser": "~0.4.0"
   },
   "devDependencies": {

--- a/readme.md
+++ b/readme.md
@@ -29,7 +29,7 @@ var fs = require('fs')
 var src = fs.readFileSync('rewire.sh','utf8')
 
 console.log(falafel(src, function (node) {
-  if (node.type === 'simple_command' && node.name.text === 'sudo') {
+  if (node.type === 'Command' && node.name.text === 'sudo') {
     node.name.update('SUDO')
   }
 }).toString())
@@ -71,7 +71,7 @@ Update the current node's content by a string `str`.
 ## output.toString()
 
 Get a string from the transformed input. You can call `.toString()` sometime in
-the future if you have 
+the future if you have
 
 # install
 

--- a/test/sudo.js
+++ b/test/sudo.js
@@ -27,7 +27,7 @@ var expected = `
 
 test('sudo', function (t) {
   var output = falafel(src, function (node) {
-    if (node.type === 'simple_command' && node.name.text === 'sudo') {
+    if (node.type === 'Command' && node.name.text === 'sudo') {
       node.name.update('SUDO')
     }
   }).toString()

--- a/test/types.js
+++ b/test/types.js
@@ -13,17 +13,17 @@ test('types', function (t) {
     types.push(node.type)
   })
   t.deepEqual(types, [
-    'word',
-    'simple_command',
-    'word',
-    'parameter_expansion',
-    'word',
-    'word',
-    'word',
-    'parameter_expansion',
-    'word',
-    'simple_command',
-    'complete_command'
+    'Word',
+    'Command',
+    'Word',
+    'ParameterExpansion',
+    'Word',
+    'Word',
+    'Word',
+    'ParameterExpansion',
+    'Word',
+    'Command',
+    'Script'
   ])
   t.end()
 })


### PR DESCRIPTION
- changed AST type names to upgrade to ones used in 0.4 (see [ast.md](https://github.com/vorpaljs/bash-parser/blob/master/documents/ast.md) )
- removed the line offset calclation because versione 0.4.0 directly provides char index in loc nodes
- introduced dependency on  bash-ast-traverser to visit the AST
